### PR TITLE
feat(.gitmodules): add submodule (brigadecore/community)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".submodules/community"]
+	path = .submodules/community
+	url = https://github.com/brigadecore/community


### PR DESCRIPTION
We have a need for a test repo in brigadecore with submodules to test the `initSubmodules` functionality of Brigade's git initializer (formerly vcs sidecar).  I thought perhaps this repo might be a good candidate -- and the small-ish brigadecore/community repo a good candidate for the actual submodule.  Thoughts?  We could also create a new, dedicated test repo for this need.